### PR TITLE
Added support for using &# on hexa

### DIFF
--- a/action-lib/src/main/kotlin/com/github/frcsty/actions/util/Extensions.kt
+++ b/action-lib/src/main/kotlin/com/github/frcsty/actions/util/Extensions.kt
@@ -16,6 +16,15 @@ private val HEX_PATTERN: Pattern = Pattern.compile("#([A-Fa-f0-9]){6}")
 fun String.color(): String {
     var translation = this.colorLegacy()
 
+    val plugin: Plugin? = Bukkit.getPluginManager().getPlugin("FrozenJoin")
+
+    if (plugin != null && plugin.isEnabled) {
+        val format = plugin.config.getString("hexa-formatting")
+        if (format != null && format == "&#"){
+            translation = translation.replace("&#", "#")
+        }
+    }
+
     var matcher = HEX_PATTERN.matcher(translation)
 
     while (matcher.find()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -238,3 +238,8 @@ placeholder-cache:
 # If you want bstats to track your server leave this enabled,
 # otherwise disable it by setting it to false
 stonks: true
+
+# Here you can fix your placeholders. A lot of plugins format hex
+# using only '#', but others plugins use '&#'. Here you can select what type
+# of formatting hex colors the plugin should use: '&#' or '#'
+hexa-formatting: '#'


### PR DESCRIPTION
In almost all plugins, the way to format hexadecimal text is by using '&#'. Therefore, most placeholders are composed this way. What I did in this pull request is to add a new option in the config.yml file, that allows you to select what kind of formatting to use, whether '&#' or '#'.